### PR TITLE
Fix integration tests failing on K8s creating resources 

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -91,3 +91,11 @@ jobs:
       - name: Get operator logs
         run: kubectl logs --tail 100 -ntesting -loperator.juju.is/name=zenml-server
         if: failure()
+
+      - name: Get container logs
+        run: kubectl logs --tail 100 -ntesting -lapp.kubernetes.io/name=zenml-server -czenml-server
+        if: failure()
+
+      - name: Get container
+        run: kubectl get pods -ntesting -lapp.kubernetes.io/name=zenml-server -oyaml
+        if: failure()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -69,8 +69,8 @@ jobs:
         with:
           juju-channel: "3.1/stable"
           provider: microk8s
-          channel: 1.28-strict/stable
-          microk8s-addons: "dns rbac storage metallb:10.64.140.43-10.64.140.49"
+          channel: 1.25-strict/stable
+          microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
       - name: Run integration tests
         run: sg snap_microk8s -c "tox -vve integration -- --model testing"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -70,7 +70,7 @@ jobs:
           juju-channel: "3.1/stable"
           provider: microk8s
           channel: 1.28-strict/stable
-          microk8s-addons: "dns storage metallb:10.64.140.43-10.64.140.49"
+          microk8s-addons: "dns rbac storage metallb:10.64.140.43-10.64.140.49"
 
       - name: Run integration tests
         run: sg snap_microk8s -c "tox -vve integration -- --model testing"
@@ -98,4 +98,8 @@ jobs:
 
       - name: Get container
         run: kubectl describe po -ntesting -lapp.kubernetes.io/name=zenml-server
+        if: failure()
+
+      - name: Get jobs
+        run: kubectl get jobs -ntesting
         if: failure()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -97,5 +97,5 @@ jobs:
         if: failure()
 
       - name: Get container
-        run: kubectl get pods -ntesting -lapp.kubernetes.io/name=zenml-server -oyaml
+        run: kubectl describe po -ntesting -lapp.kubernetes.io/name=zenml-server
         if: failure()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ juju add-model dev
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
 # Deploy the charm
-juju deploy ./zenml-server_ubuntu-22.04-amd64.charm \
+juju deploy ./zenml-server_ubuntu-20.04-amd64.charm \
     --resource oci-image=$(yq '.resources."oci-image"."upstream-source"' metadata.yaml)
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ To connect the `zenml SDK` to it run
 zenml connect --uri http://localhost:31375/ --username default --password ''
 ```
 
-
 ### Build and deploy the charm manually
 
 Install dependencies
@@ -123,12 +122,12 @@ Create ZenML Charm
 charmcraft pack
 ```
 
-This step will generate a charm file **zenml-server_ubuntu-22.04-amd64.charm**
+This step will generate a charm file **zenml-server_ubuntu-20.04-amd64.charm**
 
 Deploy the ZenML server charm
 
 ```bash
-juju deploy ./zenml-server_ubuntu-22.04-amd64.charm zenml-server \
+juju deploy ./zenml-server_ubuntu-20.04-amd64.charm zenml-server \
     --resource oci-image=$(yq '.resources."oci-image"."upstream-source"' metadata.yaml)
 ```
 
@@ -145,6 +144,7 @@ Run `juju status --watch 2s` to observe the charm deployment and after all the a
 ```
 http://localhost:31375/
 ```
+
 With the same credentials
 
 ## Integrate ZenML Server with Charmed Kubeflow

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,7 +16,7 @@ RELATIONAL_DB_CHARM_NAME = "mysql-k8s"
 
 class TestCharm:
     @retry(stop=stop_after_delay(300), wait=wait_fixed(10))
-    def _check_can_connect_with_zenml_client(self, zenml_url: str):
+    async def _check_can_connect_with_zenml_client(self, zenml_url: str):
         zenml_subprocess = subprocess.run(
             ["zenml", "connect", "--url", zenml_url, "--username", "default", "--password", ""]
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,7 +1,7 @@
 import logging
 import subprocess
-from pathlib import Path
 import time
+from pathlib import Path
 
 import pytest
 import yaml
@@ -34,8 +34,8 @@ class TestCharm:
 
         await ops_test.model.relate(RELATIONAL_DB_CHARM_NAME, CHARM_NAME)
 
-        time.wait(10) # Wait for relation to get active setup
-        
+        time.wait(10)  # Wait for relation to get active setup
+
         await ops_test.model.wait_for_idle(
             apps=[RELATIONAL_DB_CHARM_NAME, CHARM_NAME],
             status="active",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
+from tenacity import retry, stop_after_delay, wait_fixed
 
 logger = logging.getLogger(__name__)
 
@@ -14,12 +15,23 @@ RELATIONAL_DB_CHARM_NAME = "mysql-k8s"
 
 
 class TestCharm:
+    @retry(stop=stop_after_delay(300), wait=wait_fixed(10))
+    async def _check_can_connect_with_zenml_client(self, zenml_url: str):
+        zenml_subprocess = subprocess.run(
+            ["zenml", "connect", "--url", zenml_url, "--username", "default", "--password", ""]
+        )
+        logger.info(f"ZenML command stdout: {zenml_subprocess.stdout}")
+        if zenml_subprocess.stderr:
+            logger.info(f"ZenML command stderr: {zenml_subprocess.stderr}")
+        assert zenml_subprocess.returncode == 0
+
     @pytest.mark.abort_on_fail
     @pytest.mark.skip_if_deployed
     async def test_successfull_deploy_senario(self, ops_test: OpsTest):
         await ops_test.model.deploy(
             RELATIONAL_DB_CHARM_NAME,
             channel="8.0/stable",
+            series="jammy",
             trust=True,
         )
         await ops_test.model.relate(CHARM_NAME, RELATIONAL_DB_CHARM_NAME)
@@ -36,10 +48,5 @@ class TestCharm:
         config = await ops_test.model.applications[CHARM_NAME].get_config()
         zenml_nodeport = config["zenml_nodeport"]["value"]
         zenml_url = f"http://localhost:{zenml_nodeport}"
-        zenml_subprocess = subprocess.run(
-            ["zenml", "connect", "--url", zenml_url, "--username", "default", "--password", ""]
-        )
-        logger.info(f"ZenML command stdout: {zenml_subprocess.stdout}")
-        if zenml_subprocess.stderr:
-            logger.info(f"ZenML command stderr: {zenml_subprocess.stderr}")
-        assert zenml_subprocess.returncode == 0
+
+        self._check_can_connect_with_zenml_client(zenml_url=zenml_url)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -17,7 +17,7 @@ RELATIONAL_DB_CHARM_NAME = "mysql-k8s"
 
 class TestCharm:
     @retry(stop=stop_after_delay(100), wait=wait_fixed(10))
-    async def _test_can_connect_with_zenml_client(self, zenml_url: str):
+    def _test_can_connect_with_zenml_client(self, zenml_url: str):
         zenml_subprocess = subprocess.run(
             ["zenml", "connect", "--url", zenml_url, "--username", "default", "--password", ""]
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,7 +16,7 @@ RELATIONAL_DB_CHARM_NAME = "mysql-k8s"
 
 class TestCharm:
     @retry(stop=stop_after_delay(300), wait=wait_fixed(10))
-    async def _check_can_connect_with_zenml_client(self, zenml_url: str):
+    def _check_can_connect_with_zenml_client(self, zenml_url: str):
         zenml_subprocess = subprocess.run(
             ["zenml", "connect", "--url", zenml_url, "--username", "default", "--password", ""]
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -34,7 +34,7 @@ class TestCharm:
 
         await ops_test.model.relate(RELATIONAL_DB_CHARM_NAME, CHARM_NAME)
 
-        time.wait(10)  # Wait for relation to get active setup
+        time.sleep(10)  # Wait for relation to get active setup
 
         await ops_test.model.wait_for_idle(
             apps=[RELATIONAL_DB_CHARM_NAME, CHARM_NAME],

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -20,7 +20,6 @@ class TestCharm:
         await ops_test.model.deploy(
             RELATIONAL_DB_CHARM_NAME,
             channel="8.0/stable",
-            series="jammy",
             trust=True,
         )
         await ops_test.model.relate(CHARM_NAME, RELATIONAL_DB_CHARM_NAME)


### PR DESCRIPTION
Pin integration test MicroK8s version from 1.28-strict to 1.25-strict due to `unit.mysql-k8s/0.juju-log database:2: Failed to create k8s services for endpoints` error while establishing relation