### PR TITLE
bump ZenML server image version to 0.54.1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: docker.io/zenmldocker/zenml-server:0.54.0
+    upstream-source: docker.io/zenmldocker/zenml-server:0.54.1
 requires:
   relational-db:
     interface: mysql_client
@@ -33,10 +33,10 @@ requires:
             rewrite:
               type: string
           required:
-          - service
-          - port
-          - namespace
-          - prefix
+            - service
+            - port
+            - namespace
+            - prefix
       v1:
         requires:
           type: object
@@ -50,8 +50,8 @@ requires:
             rewrite:
               type: string
           required:
-          - service
-          - port
-          - prefix
+            - service
+            - port
+            - prefix
     versions: [v1]
     __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -3,5 +3,5 @@ jinja2
 juju<4.0
 pytest-operator
 requests
-zenml==0.54.0
+zenml==0.54.1
 -r requirements.txt


### PR DESCRIPTION
Bump ZenML server image version to 0.54.1

Source changelog available [here](https://github.com/zenml-io/zenml/releases/tag/0.54.1)